### PR TITLE
fix(package): updated response to call dunction instead of exporting it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import File from "./File"
 import Sorter from "./Sorter"
 
-export default (() => {
-	const packageFile = new File("./package.json")
+const depensort = () => {
+	const packageFile = new File(`${process.cwd()}/package.json`)
 	const packageValues = packageFile.read()
 	if (packageValues.dependencies) {
 		packageValues.dependencies = new Sorter(packageValues.dependencies).sort()
@@ -17,4 +17,6 @@ export default (() => {
 		packageValues.overrides = new Sorter(packageValues.overrides).sort()
 	}
 	packageFile.write(packageValues)
-})()
+}
+
+depensort()


### PR DESCRIPTION
BREAKING CHANGE: removed the export of the function and instead called the function

fixes #9

update the process in index file to run the sort function instead of exporting it

## Pull request type
-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation content changes
-   [ ] Other (please describe):

## What is the current behavior?
as the function call was being exported it was causing a bug where the package was running the sorter for the packages json instead of the caller app

## What is the new behavior?
- The function is called with the current working directory's package.json file passed to the sorter
- Nothing is exported in index.js files

### Testing

-   [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

-   [x] I have added documentation for new/changed functionality in this PR
-   [x] All active GitHub checks for tests, formatting, and security are passing
-   [x] The correct base branch is being used, if not `master`
